### PR TITLE
Add test npm command w/ browser-sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@ Detailed documentation and other information about mParticle SDK can be found at
 Once you have signed up to the mParticle platform and have a key for your App, you can begin to use the SDK by embedding the following
 script tag in your web page, replacing `"YOUR_API_KEY"` with your key.
 
-```groovy
+```html
 <script type="text/javascript">
-
-(function (apiKey) {
+  (function (apiKey) {
     window.mParticle = window.mParticle || {};
     window.mParticle.config = window.mParticle.config || {};
     window.mParticle.config.rq = [];
@@ -28,14 +27,13 @@ script tag in your web page, replacing `"YOUR_API_KEY"` with your key.
     mp.src = ('https:' == document.location.protocol ? 'https://jssdkcdns' : 'http://jssdkcdn') + '.mparticle.com/js/v1/' + apiKey + '/mparticle.js';
     var s = document.getElementsByTagName('script')[0];
     s.parentNode.insertBefore(mp, s);
-})('YOUR_API_KEY');
-
+  })('YOUR_API_KEY');
 </script>
 ```
 
 You can then log events, for example, as follows:
 
-```groovy
+```javascript
 mParticle.logEvent('Play Movie', mParticle.EventType.Navigation, {'movie_length':'127 minutes','rating':'PG'});
 ```
 
@@ -62,9 +60,22 @@ Similar to other mParticle SDKs, the Javascript SDK is able to automatically inc
 
 ## Running the Tests
 
-A suite of test cases can be run by serving the /test directory from a web server (such as [serve](https://www.npmjs.com/package/serve)),
-and pointing a web browser to index.html. This will execute the tests and also display code coverage results. Note that serving the test
+Prior to running the tests please install all dev dependencies via an npm install:
+
+```bash
+$ npm install
+```
+
+A suite of test cases can be run by serving the `/test` directory from a web server (such as [serve](https://www.npmjs.com/package/serve)),
+and pointing a web browser to `index.html`. This will execute the tests and also display code coverage results. Note that serving the test
 directory from the file system directly will not work.
+
+You can also run the tests by executing the npm test script:
+
+```bash
+$ npm test
+```
+The test script will use the browser-sync module to serve `test/index.html`, open the tests in a browser, and auto-refresh when a change is made to `mparticle.js` or any of the test files.
 
 ## Support
 

--- a/package.json
+++ b/package.json
@@ -2,9 +2,13 @@
   "name": "mparticle-sdk-javascript",
   "description": "mParticle core Javascript SDK",
   "repository": "https://github.com/mParticle/mparticle-sdk-javascript",
+  "scripts": {
+    "test": "node test/runner.js"
+  },
   "devDependencies": {
     "blanket": "1.1.7",
-    "should": "^7.1.0",
-    "mocha": "^2.3.2"
+    "browser-sync": "^2.18.5",
+    "mocha": "^2.3.2",
+    "should": "^7.1.0"
   }
 }

--- a/test/runner.js
+++ b/test/runner.js
@@ -1,0 +1,13 @@
+const browserSync = require('browser-sync').create();
+
+browserSync.watch('mparticle.js').on('change', browserSync.reload);
+browserSync.watch('test/*.js').on('change', browserSync.reload);
+browserSync.watch('test/index.html').on('change', browserSync.reload);
+
+browserSync.init({
+  port: 3000,
+  startPath: '/test/index.html',
+  server: {
+    index: 'test/index.html'
+  }
+});


### PR DESCRIPTION
Leverages browser-sync to run mocha tests in browser w/ auto-refreshing on file changes. Includes relevant updates to README.